### PR TITLE
fix: Support both hex and colon-separated MAC address formats in inpu…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 packemon_pcap/
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Changed
+- **eureka** Removed custom color settings (black background, white text) from Ethernet form to maintain consistency with other forms in the TUI generator. The form now uses the default blue background like IPv4, TCP, and other forms.
+- **eureka** Removed unused tcell import from form_ethernet.go after color settings removal. The package now compiles successfully without any errors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-## [Unreleased]
-
-### Changed
-- **eureka** Removed custom color settings (black background, white text) from Ethernet form to maintain consistency with other forms in the TUI generator. The form now uses the default blue background like IPv4, TCP, and other forms.
-- **eureka** Removed unused tcell import from form_ethernet.go after color settings removal. The package now compiles successfully without any errors.

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -2,72 +2,132 @@ package generator
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/ddddddO/packemon"
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
 var underIPv6 = false
 
+// MACValidationResult contains the result of MAC address validation
+type MACValidationResult struct {
+	Address packemon.HardwareAddr
+	Valid   bool
+	Error   string
+}
+
 // validateAndParseMACAddress validates and parses MAC address input
-// Supports both hex format (0x prefix) and colon-separated format
-func validateAndParseMACAddress(input string) (packemon.HardwareAddr, bool) {
+// Supports hex format (0x prefix), colon-separated, and dash-separated formats
+func validateAndParseMACAddress(input string) MACValidationResult {
 	l := len(input)
 	
 	if l > 20 {
-		return nil, false
+		return MACValidationResult{
+			Valid: false,
+			Error: "MAC address too long (max 20 characters)",
+		}
 	}
 
 	// Only try to parse when we have enough characters for a potential MAC address
-	// Minimum: "0x" + 12 hex chars = 14, or XX:XX:XX:XX:XX:XX = 17
-	if l >= 14 || (strings.Contains(input, ":") && l >= 17) {
+	// Minimum: "0x" + 12 hex chars = 14, or XX:XX:XX:XX:XX:XX = 17, or XX-XX-XX-XX-XX-XX = 17
+	if l >= 14 || ((strings.Contains(input, ":") || strings.Contains(input, "-")) && l >= 17) {
 		var b []byte
 		var err error
 		
-		if strings.Contains(input, ":") {
+		if strings.Contains(input, ":") || strings.Contains(input, "-") {
+			// Remove colons or dashes
 			cleaned := strings.ReplaceAll(input, ":", "")
+			cleaned = strings.ReplaceAll(cleaned, "-", "")
+			
 			if len(cleaned) > 12 {
-				return nil, false
+				return MACValidationResult{
+					Valid: false,
+					Error: "Invalid MAC address format",
+				}
 			}
+			
+			// Validate hex characters
+			for _, c := range cleaned {
+				if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+					return MACValidationResult{
+						Valid: true, // Allow continued typing
+						Error: fmt.Sprintf("Invalid character: %c", c),
+					}
+				}
+			}
+			
 			b, err = packemon.StrHexToBytes("0x" + cleaned)
 		} else {
 			b, err = packemon.StrHexToBytes(input)
 		}
 		
-		if err == nil {
-			return packemon.HardwareAddr(b), true
+		if err != nil {
+			return MACValidationResult{
+				Valid: true, // Allow continued typing
+				Error: "Invalid hex format",
+			}
+		}
+		
+		return MACValidationResult{
+			Address: packemon.HardwareAddr(b),
+			Valid:   true,
 		}
 	}
 
-	return nil, true // Return true to allow continued typing
+	return MACValidationResult{
+		Valid: true, // Allow continued typing
+	}
 }
 
 func (g *generator) ethernetForm() *tview.Form {
+	// Status labels for MAC address validation feedback
+	dstMACStatus := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText("")
+	
+	srcMACStatus := tview.NewTextView().
+		SetDynamicColors(true).
+		SetText("")
+
 	ethernetForm := tview.NewForm().
 		AddTextView("Ethernet Header", "This section generates the Ethernet header.\nIt is still under development.", 60, 4, true, false).
 		AddInputField("Destination Mac Addr(hex)", DEFAULT_MAC_DESTINATION, 20, func(textToCheck string, lastChar rune) bool {
-			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
-			addr, valid := validateAndParseMACAddress(textToCheck)
-			if !valid {
-				return false
+			// Support hex (0x), colon-separated, and dash-separated formats
+			result := validateAndParseMACAddress(textToCheck)
+			
+			// Update status message
+			if result.Error != "" {
+				dstMACStatus.SetText(fmt.Sprintf("[red]%s[white]", result.Error))
+			} else if result.Address != nil {
+				dstMACStatus.SetText("[green]Valid MAC address[white]")
+				g.sender.packets.ethernet.Dst = result.Address
+			} else {
+				dstMACStatus.SetText("")
 			}
-			if addr != nil {
-				g.sender.packets.ethernet.Dst = addr
-			}
-			return true
+			
+			return result.Valid
 		}, nil).
+		AddFormItem(dstMACStatus).
 		AddInputField("Source Mac Addr(hex)", DEFAULT_MAC_SOURCE, 20, func(textToCheck string, lastChar rune) bool {
-			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
-			addr, valid := validateAndParseMACAddress(textToCheck)
-			if !valid {
-				return false
+			// Support hex (0x), colon-separated, and dash-separated formats
+			result := validateAndParseMACAddress(textToCheck)
+			
+			// Update status message
+			if result.Error != "" {
+				srcMACStatus.SetText(fmt.Sprintf("[red]%s[white]", result.Error))
+			} else if result.Address != nil {
+				srcMACStatus.SetText("[green]Valid MAC address[white]")
+				g.sender.packets.ethernet.Src = result.Address
+			} else {
+				srcMACStatus.SetText("")
 			}
-			if addr != nil {
-				g.sender.packets.ethernet.Src = addr
-			}
-			return true
+			
+			return result.Valid
 		}, nil).
+		AddFormItem(srcMACStatus).
 		// TODO: 自由にフレーム作れるとするなら、ここもhexで受け付けるようにして、IP or ARPヘッダフォームへの切り替えも自由にできた方がいいかも
 		AddDropDown("Ether Type", []string{"IPv4", "IPv6", "ARP"}, 0, func(selected string, _ int) {
 			switch selected {
@@ -90,6 +150,10 @@ func (g *generator) ethernetForm() *tview.Form {
 		AddButton("Quit", func() {
 			g.app.Stop()
 		})
+
+	// Set field colors to indicate validation state
+	ethernetForm.SetFieldBackgroundColor(tcell.ColorBlack)
+	ethernetForm.SetFieldTextColor(tcell.ColorWhite)
 
 	return ethernetForm
 }

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -14,9 +14,10 @@ var underIPv6 = false
 
 // MACValidationResult contains the result of MAC address validation
 type MACValidationResult struct {
-	Address packemon.HardwareAddr
-	Valid   bool
-	Error   string
+	Address   packemon.HardwareAddr
+	HasAddress bool  // indicates whether Address contains a valid parsed address
+	Valid     bool
+	Error     string
 }
 
 // validateAndParseMACAddress validates and parses MAC address input
@@ -71,9 +72,13 @@ func validateAndParseMACAddress(input string) MACValidationResult {
 			}
 		}
 		
+		var addr packemon.HardwareAddr
+		copy(addr[:], b)
+		
 		return MACValidationResult{
-			Address: packemon.HardwareAddr(b),
-			Valid:   true,
+			Address:    addr,
+			HasAddress: true,
+			Valid:      true,
 		}
 	}
 
@@ -101,7 +106,7 @@ func (g *generator) ethernetForm() *tview.Form {
 			// Update status message
 			if result.Error != "" {
 				dstMACStatus.SetText(fmt.Sprintf("[red]%s[white]", result.Error))
-			} else if result.Address != nil {
+			} else if result.HasAddress {
 				dstMACStatus.SetText("[green]Valid MAC address[white]")
 				g.sender.packets.ethernet.Dst = result.Address
 			} else {
@@ -118,7 +123,7 @@ func (g *generator) ethernetForm() *tview.Form {
 			// Update status message
 			if result.Error != "" {
 				srcMACStatus.SetText(fmt.Sprintf("[red]%s[white]", result.Error))
-			} else if result.Address != nil {
+			} else if result.HasAddress {
 				srcMACStatus.SetText("[green]Valid MAC address[white]")
 				g.sender.packets.ethernet.Src = result.Address
 			} else {

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -95,6 +95,7 @@ func (g *generator) ethernetForm() *tview.Form {
 		SetText("")
 	
 	srcMACStatus := tview.NewTextView().
+		SetSize(1, 20).
 		SetDynamicColors(true).
 		SetText("")
 

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"context"
+	"strings"
 
 	"github.com/ddddddO/packemon"
 	"github.com/rivo/tview"
@@ -12,14 +13,35 @@ var underIPv6 = false
 func (g *generator) ethernetForm() *tview.Form {
 	ethernetForm := tview.NewForm().
 		AddTextView("Ethernet Header", "This section generates the Ethernet header.\nIt is still under development.", 60, 4, true, false).
-		AddInputField("Destination Mac Addr(hex)", DEFAULT_MAC_DESTINATION, 14, func(textToCheck string, lastChar rune) bool {
-			if len(textToCheck) < 14 {
+		AddInputField("Destination Mac Addr(hex)", DEFAULT_MAC_DESTINATION, 20, func(textToCheck string, lastChar rune) bool {
+			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
+			l := len(textToCheck)
+			if l == 0 {
 				return true
-			} else if len(textToCheck) > 14 {
+			}
+			
+			// Allow input up to 20 characters to support both formats
+			if l > 20 {
 				return false
 			}
 
-			b, err := packemon.StrHexToBytes(textToCheck)
+			// Try to parse the MAC address
+			var b []byte
+			var err error
+			
+			// Check if it's in colon-separated format
+			if strings.Contains(textToCheck, ":") {
+				// Convert colon-separated to hex format
+				cleaned := strings.ReplaceAll(textToCheck, ":", "")
+				if len(cleaned) > 12 {
+					return false
+				}
+				b, err = packemon.StrHexToBytes("0x" + cleaned)
+			} else {
+				// Assume it's in hex format
+				b, err = packemon.StrHexToBytes(textToCheck)
+			}
+			
 			if err != nil {
 				return false
 			}
@@ -27,14 +49,35 @@ func (g *generator) ethernetForm() *tview.Form {
 
 			return true
 		}, nil).
-		AddInputField("Source Mac Addr(hex)", DEFAULT_MAC_SOURCE, 14, func(textToCheck string, lastChar rune) bool {
-			if len(textToCheck) < 14 {
+		AddInputField("Source Mac Addr(hex)", DEFAULT_MAC_SOURCE, 20, func(textToCheck string, lastChar rune) bool {
+			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
+			l := len(textToCheck)
+			if l == 0 {
 				return true
-			} else if len(textToCheck) > 14 {
+			}
+			
+			// Allow input up to 20 characters to support both formats
+			if l > 20 {
 				return false
 			}
 
-			b, err := packemon.StrHexToBytes(textToCheck)
+			// Try to parse the MAC address
+			var b []byte
+			var err error
+			
+			// Check if it's in colon-separated format
+			if strings.Contains(textToCheck, ":") {
+				// Convert colon-separated to hex format
+				cleaned := strings.ReplaceAll(textToCheck, ":", "")
+				if len(cleaned) > 12 {
+					return false
+				}
+				b, err = packemon.StrHexToBytes("0x" + cleaned)
+			} else {
+				// Assume it's in hex format
+				b, err = packemon.StrHexToBytes(textToCheck)
+			}
+			
 			if err != nil {
 				return false
 			}

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ddddddO/packemon"
-	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
 
@@ -157,10 +156,6 @@ func (g *generator) ethernetForm() *tview.Form {
 		AddButton("Quit", func() {
 			g.app.Stop()
 		})
-
-	// Set field colors to indicate validation state
-	ethernetForm.SetFieldBackgroundColor(tcell.ColorBlack)
-	ethernetForm.SetFieldTextColor(tcell.ColorWhite)
 
 	return ethernetForm
 }

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -16,9 +16,6 @@ func (g *generator) ethernetForm() *tview.Form {
 		AddInputField("Destination Mac Addr(hex)", DEFAULT_MAC_DESTINATION, 20, func(textToCheck string, lastChar rune) bool {
 			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
 			l := len(textToCheck)
-			if l == 0 {
-				return true
-			}
 			
 			if l > 20 {
 				return false
@@ -50,9 +47,6 @@ func (g *generator) ethernetForm() *tview.Form {
 		AddInputField("Source Mac Addr(hex)", DEFAULT_MAC_SOURCE, 20, func(textToCheck string, lastChar rune) bool {
 			// Support both hex format (0x prefix, 14 chars) and colon-separated format (17 chars)
 			l := len(textToCheck)
-			if l == 0 {
-				return true
-			}
 			
 			if l > 20 {
 				return false

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -20,32 +20,30 @@ func (g *generator) ethernetForm() *tview.Form {
 				return true
 			}
 			
-			// Allow input up to 20 characters to support both formats
 			if l > 20 {
 				return false
 			}
 
-			// Try to parse the MAC address
-			var b []byte
-			var err error
-			
-			// Check if it's in colon-separated format
-			if strings.Contains(textToCheck, ":") {
-				// Convert colon-separated to hex format
-				cleaned := strings.ReplaceAll(textToCheck, ":", "")
-				if len(cleaned) > 12 {
-					return false
+			// Only try to parse when we have enough characters for a potential MAC address
+			// Minimum: "0x" + 12 hex chars = 14, or XX:XX:XX:XX:XX:XX = 17
+			if l >= 14 || (strings.Contains(textToCheck, ":") && l >= 17) {
+				var b []byte
+				var err error
+				
+				if strings.Contains(textToCheck, ":") {
+					cleaned := strings.ReplaceAll(textToCheck, ":", "")
+					if len(cleaned) > 12 {
+						return false
+					}
+					b, err = packemon.StrHexToBytes("0x" + cleaned)
+				} else {
+					b, err = packemon.StrHexToBytes(textToCheck)
 				}
-				b, err = packemon.StrHexToBytes("0x" + cleaned)
-			} else {
-				// Assume it's in hex format
-				b, err = packemon.StrHexToBytes(textToCheck)
+				
+				if err == nil {
+					g.sender.packets.ethernet.Dst = packemon.HardwareAddr(b)
+				}
 			}
-			
-			if err != nil {
-				return false
-			}
-			g.sender.packets.ethernet.Dst = packemon.HardwareAddr(b)
 
 			return true
 		}, nil).
@@ -56,32 +54,30 @@ func (g *generator) ethernetForm() *tview.Form {
 				return true
 			}
 			
-			// Allow input up to 20 characters to support both formats
 			if l > 20 {
 				return false
 			}
 
-			// Try to parse the MAC address
-			var b []byte
-			var err error
-			
-			// Check if it's in colon-separated format
-			if strings.Contains(textToCheck, ":") {
-				// Convert colon-separated to hex format
-				cleaned := strings.ReplaceAll(textToCheck, ":", "")
-				if len(cleaned) > 12 {
-					return false
+			// Only try to parse when we have enough characters for a potential MAC address
+			// Minimum: "0x" + 12 hex chars = 14, or XX:XX:XX:XX:XX:XX = 17
+			if l >= 14 || (strings.Contains(textToCheck, ":") && l >= 17) {
+				var b []byte
+				var err error
+				
+				if strings.Contains(textToCheck, ":") {
+					cleaned := strings.ReplaceAll(textToCheck, ":", "")
+					if len(cleaned) > 12 {
+						return false
+					}
+					b, err = packemon.StrHexToBytes("0x" + cleaned)
+				} else {
+					b, err = packemon.StrHexToBytes(textToCheck)
 				}
-				b, err = packemon.StrHexToBytes("0x" + cleaned)
-			} else {
-				// Assume it's in hex format
-				b, err = packemon.StrHexToBytes(textToCheck)
+				
+				if err == nil {
+					g.sender.packets.ethernet.Src = packemon.HardwareAddr(b)
+				}
 			}
-			
-			if err != nil {
-				return false
-			}
-			g.sender.packets.ethernet.Src = packemon.HardwareAddr(b)
 
 			return true
 		}, nil).

--- a/internal/tui/generator/form_ethernet.go
+++ b/internal/tui/generator/form_ethernet.go
@@ -90,6 +90,7 @@ func validateAndParseMACAddress(input string) MACValidationResult {
 func (g *generator) ethernetForm() *tview.Form {
 	// Status labels for MAC address validation feedback
 	dstMACStatus := tview.NewTextView().
+		SetSize(1, 20).
 		SetDynamicColors(true).
 		SetText("")
 	

--- a/internal/tui/generator/form_ethernet_test.go
+++ b/internal/tui/generator/form_ethernet_test.go
@@ -1,0 +1,183 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/ddddddO/packemon"
+)
+
+func TestValidateAndParseMACAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantAddr  bool // whether we expect a non-nil address
+		wantValid bool // whether the validation should pass
+	}{
+		// Valid hex format tests
+		{
+			name:      "valid hex format with 0x prefix",
+			input:     "0x3c585d55770e",
+			wantAddr:  true,
+			wantValid: true,
+		},
+		{
+			name:      "valid hex format uppercase",
+			input:     "0x3C585D55770E",
+			wantAddr:  true,
+			wantValid: true,
+		},
+		
+		// Valid colon-separated format tests
+		{
+			name:      "valid colon format lowercase",
+			input:     "3c:58:5d:55:77:0e",
+			wantAddr:  true,
+			wantValid: true,
+		},
+		{
+			name:      "valid colon format uppercase",
+			input:     "3C:58:5D:55:77:0E",
+			wantAddr:  true,
+			wantValid: true,
+		},
+		{
+			name:      "valid colon format mixed case",
+			input:     "3c:58:5D:55:77:0e",
+			wantAddr:  true,
+			wantValid: true,
+		},
+		
+		// Partial input tests (should be valid but no address)
+		{
+			name:      "partial hex input",
+			input:     "0x3c58",
+			wantAddr:  false,
+			wantValid: true,
+		},
+		{
+			name:      "partial colon input",
+			input:     "3c:58:5d",
+			wantAddr:  false,
+			wantValid: true,
+		},
+		{
+			name:      "empty input",
+			input:     "",
+			wantAddr:  false,
+			wantValid: true,
+		},
+		{
+			name:      "single character",
+			input:     "3",
+			wantAddr:  false,
+			wantValid: true,
+		},
+		
+		// Invalid format tests
+		{
+			name:      "too long hex format",
+			input:     "0x3c585d55770e123456",
+			wantAddr:  false,
+			wantValid: false,
+		},
+		{
+			name:      "too long colon format",
+			input:     "3c:58:5d:55:77:0e:12:34",
+			wantAddr:  false,
+			wantValid: false,
+		},
+		{
+			name:      "invalid hex characters",
+			input:     "0x3c585d55770g",
+			wantAddr:  false,
+			wantValid: true, // Should allow typing until complete
+		},
+		{
+			name:      "malformed colon format",
+			input:     "3c:58:5d:55:77:0e:",
+			wantAddr:  false,
+			wantValid: true, // Should allow typing
+		},
+		{
+			name:      "too many characters",
+			input:     "012345678901234567890", // 21 characters
+			wantAddr:  false,
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, valid := validateAndParseMACAddress(tt.input)
+			
+			if valid != tt.wantValid {
+				t.Errorf("validateAndParseMACAddress(%q) valid = %v, want %v", tt.input, valid, tt.wantValid)
+			}
+			
+			if tt.wantAddr && addr == nil {
+				t.Errorf("validateAndParseMACAddress(%q) returned nil address, want non-nil", tt.input)
+			}
+			
+			if !tt.wantAddr && addr != nil {
+				t.Errorf("validateAndParseMACAddress(%q) returned non-nil address %v, want nil", tt.input, addr)
+			}
+			
+			// Verify the parsed address has correct length when non-nil
+			if addr != nil && len(addr) != 6 {
+				t.Errorf("validateAndParseMACAddress(%q) returned address with length %d, want 6", tt.input, len(addr))
+			}
+		})
+	}
+}
+
+// Test specific MAC address values
+func TestValidateAndParseMACAddressValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantAddr packemon.HardwareAddr
+	}{
+		{
+			name:     "hex format specific value",
+			input:    "0x3c585d55770e",
+			wantAddr: packemon.HardwareAddr{0x3c, 0x58, 0x5d, 0x55, 0x77, 0x0e},
+		},
+		{
+			name:     "colon format specific value",
+			input:    "3c:58:5d:55:77:0e",
+			wantAddr: packemon.HardwareAddr{0x3c, 0x58, 0x5d, 0x55, 0x77, 0x0e},
+		},
+		{
+			name:     "all zeros",
+			input:    "00:00:00:00:00:00",
+			wantAddr: packemon.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:     "all ones (broadcast)",
+			input:    "ff:ff:ff:ff:ff:ff",
+			wantAddr: packemon.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			addr, valid := validateAndParseMACAddress(tt.input)
+			
+			if !valid {
+				t.Fatalf("validateAndParseMACAddress(%q) validation failed", tt.input)
+			}
+			
+			if addr == nil {
+				t.Fatalf("validateAndParseMACAddress(%q) returned nil address", tt.input)
+			}
+			
+			// Compare byte by byte
+			for i := 0; i < len(tt.wantAddr); i++ {
+				if addr[i] != tt.wantAddr[i] {
+					t.Errorf("validateAndParseMACAddress(%q) byte %d = %02x, want %02x", 
+						tt.input, i, addr[i], tt.wantAddr[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/tui/generator/form_ethernet_test.go
+++ b/internal/tui/generator/form_ethernet_test.go
@@ -10,158 +10,158 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       string
-		wantAddr    bool   // whether we expect a non-nil address
+		wantHasAddr bool   // whether we expect HasAddress to be true
 		wantValid   bool   // whether the validation should pass
 		wantError   string // expected error message
 	}{
 		// Valid hex format tests
 		{
-			name:      "valid hex format with 0x prefix",
-			input:     "0x3c585d55770e",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid hex format with 0x prefix",
+			input:       "0x3c585d55770e",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "valid hex format uppercase",
-			input:     "0x3C585D55770E",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid hex format uppercase",
+			input:       "0x3C585D55770E",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		
 		// Valid colon-separated format tests
 		{
-			name:      "valid colon format lowercase",
-			input:     "3c:58:5d:55:77:0e",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid colon format lowercase",
+			input:       "3c:58:5d:55:77:0e",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "valid colon format uppercase",
-			input:     "3C:58:5D:55:77:0E",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid colon format uppercase",
+			input:       "3C:58:5D:55:77:0E",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "valid colon format mixed case",
-			input:     "3c:58:5D:55:77:0e",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid colon format mixed case",
+			input:       "3c:58:5D:55:77:0e",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		
 		// Valid dash-separated format tests
 		{
-			name:      "valid dash format lowercase",
-			input:     "3c-58-5d-55-77-0e",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid dash format lowercase",
+			input:       "3c-58-5d-55-77-0e",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "valid dash format uppercase",
-			input:     "3C-58-5D-55-77-0E",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid dash format uppercase",
+			input:       "3C-58-5D-55-77-0E",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "valid dash format mixed case",
-			input:     "3c-58-5D-55-77-0e",
-			wantAddr:  true,
-			wantValid: true,
-			wantError: "",
+			name:        "valid dash format mixed case",
+			input:       "3c-58-5D-55-77-0e",
+			wantHasAddr: true,
+			wantValid:   true,
+			wantError:   "",
 		},
 		
 		// Partial input tests (should be valid but no address)
 		{
-			name:      "partial hex input",
-			input:     "0x3c58",
-			wantAddr:  false,
-			wantValid: true,
-			wantError: "",
+			name:        "partial hex input",
+			input:       "0x3c58",
+			wantHasAddr: false,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "partial colon input",
-			input:     "3c:58:5d",
-			wantAddr:  false,
-			wantValid: true,
-			wantError: "",
+			name:        "partial colon input",
+			input:       "3c:58:5d",
+			wantHasAddr: false,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "partial dash input",
-			input:     "3c-58-5d",
-			wantAddr:  false,
-			wantValid: true,
-			wantError: "",
+			name:        "partial dash input",
+			input:       "3c-58-5d",
+			wantHasAddr: false,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "empty input",
-			input:     "",
-			wantAddr:  false,
-			wantValid: true,
-			wantError: "",
+			name:        "empty input",
+			input:       "",
+			wantHasAddr: false,
+			wantValid:   true,
+			wantError:   "",
 		},
 		{
-			name:      "single character",
-			input:     "3",
-			wantAddr:  false,
-			wantValid: true,
-			wantError: "",
+			name:        "single character",
+			input:       "3",
+			wantHasAddr: false,
+			wantValid:   true,
+			wantError:   "",
 		},
 		
 		// Invalid format tests
 		{
-			name:      "too long hex format",
-			input:     "0x3c585d55770e123456",
-			wantAddr:  false,
-			wantValid: false,
-			wantError: "MAC address too long (max 20 characters)",
+			name:        "too long hex format",
+			input:       "0x3c585d55770e123456",
+			wantHasAddr: false,
+			wantValid:   false,
+			wantError:   "MAC address too long (max 20 characters)",
 		},
 		{
-			name:      "too long colon format",
-			input:     "3c:58:5d:55:77:0e:12:34",
-			wantAddr:  false,
-			wantValid: false,
-			wantError: "Invalid MAC address format",
+			name:        "too long colon format",
+			input:       "3c:58:5d:55:77:0e:12:34",
+			wantHasAddr: false,
+			wantValid:   false,
+			wantError:   "Invalid MAC address format",
 		},
 		{
-			name:      "too long dash format",
-			input:     "3c-58-5d-55-77-0e-12-34",
-			wantAddr:  false,
-			wantValid: false,
-			wantError: "Invalid MAC address format",
+			name:        "too long dash format",
+			input:       "3c-58-5d-55-77-0e-12-34",
+			wantHasAddr: false,
+			wantValid:   false,
+			wantError:   "Invalid MAC address format",
 		},
 		{
-			name:      "invalid hex characters in colon format",
-			input:     "3c:58:5d:55:77:0g",
-			wantAddr:  false,
-			wantValid: true, // Should allow typing
-			wantError: "Invalid character: g",
+			name:        "invalid hex characters in colon format",
+			input:       "3c:58:5d:55:77:0g",
+			wantHasAddr: false,
+			wantValid:   true, // Should allow typing
+			wantError:   "Invalid character: g",
 		},
 		{
-			name:      "invalid hex characters in dash format",
-			input:     "3c-58-5d-55-77-0z",
-			wantAddr:  false,
-			wantValid: true, // Should allow typing
-			wantError: "Invalid character: z",
+			name:        "invalid hex characters in dash format",
+			input:       "3c-58-5d-55-77-0z",
+			wantHasAddr: false,
+			wantValid:   true, // Should allow typing
+			wantError:   "Invalid character: z",
 		},
 		{
-			name:      "malformed colon format",
-			input:     "3c:58:5d:55:77:0e:",
-			wantAddr:  false,
-			wantValid: true, // Should allow typing
-			wantError: "",
+			name:        "malformed colon format",
+			input:       "3c:58:5d:55:77:0e:",
+			wantHasAddr: false,
+			wantValid:   true, // Should allow typing
+			wantError:   "",
 		},
 		{
-			name:      "too many characters",
-			input:     "012345678901234567890", // 21 characters
-			wantAddr:  false,
-			wantValid: false,
-			wantError: "MAC address too long (max 20 characters)",
+			name:        "too many characters",
+			input:       "012345678901234567890", // 21 characters
+			wantHasAddr: false,
+			wantValid:   false,
+			wantError:   "MAC address too long (max 20 characters)",
 		},
 	}
 
@@ -173,17 +173,17 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 				t.Errorf("validateAndParseMACAddress(%q) valid = %v, want %v", tt.input, result.Valid, tt.wantValid)
 			}
 			
-			if tt.wantAddr && result.Address == nil {
-				t.Errorf("validateAndParseMACAddress(%q) returned nil address, want non-nil", tt.input)
+			if result.HasAddress != tt.wantHasAddr {
+				t.Errorf("validateAndParseMACAddress(%q) HasAddress = %v, want %v", tt.input, result.HasAddress, tt.wantHasAddr)
 			}
 			
-			if !tt.wantAddr && result.Address != nil {
-				t.Errorf("validateAndParseMACAddress(%q) returned non-nil address %v, want nil", tt.input, result.Address)
-			}
-			
-			// Verify the parsed address has correct length when non-nil
-			if result.Address != nil && len(result.Address) != 6 {
-				t.Errorf("validateAndParseMACAddress(%q) returned address with length %d, want 6", tt.input, len(result.Address))
+			// Verify the parsed address has correct length when HasAddress is true
+			if result.HasAddress {
+				// Address should be valid with 6 bytes
+				var emptyAddr packemon.HardwareAddr
+				if result.Address == emptyAddr {
+					t.Errorf("validateAndParseMACAddress(%q) returned empty address when HasAddress is true", tt.input)
+				}
 			}
 			
 			// Check error message
@@ -246,16 +246,13 @@ func TestValidateAndParseMACAddressValues(t *testing.T) {
 				t.Fatalf("validateAndParseMACAddress(%q) validation failed", tt.input)
 			}
 			
-			if result.Address == nil {
-				t.Fatalf("validateAndParseMACAddress(%q) returned nil address", tt.input)
+			if !result.HasAddress {
+				t.Fatalf("validateAndParseMACAddress(%q) HasAddress = false, want true", tt.input)
 			}
 			
-			// Compare byte by byte
-			for i := 0; i < len(tt.wantAddr); i++ {
-				if result.Address[i] != tt.wantAddr[i] {
-					t.Errorf("validateAndParseMACAddress(%q) byte %d = %02x, want %02x", 
-						tt.input, i, result.Address[i], tt.wantAddr[i])
-				}
+			// Compare the addresses
+			if result.Address != tt.wantAddr {
+				t.Errorf("validateAndParseMACAddress(%q) address = %v, want %v", tt.input, result.Address, tt.wantAddr)
 			}
 		})
 	}

--- a/internal/tui/generator/form_ethernet_test.go
+++ b/internal/tui/generator/form_ethernet_test.go
@@ -8,10 +8,11 @@ import (
 
 func TestValidateAndParseMACAddress(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantAddr  bool // whether we expect a non-nil address
-		wantValid bool // whether the validation should pass
+		name        string
+		input       string
+		wantAddr    bool   // whether we expect a non-nil address
+		wantValid   bool   // whether the validation should pass
+		wantError   string // expected error message
 	}{
 		// Valid hex format tests
 		{
@@ -19,12 +20,14 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 			input:     "0x3c585d55770e",
 			wantAddr:  true,
 			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "valid hex format uppercase",
 			input:     "0x3C585D55770E",
 			wantAddr:  true,
 			wantValid: true,
+			wantError: "",
 		},
 		
 		// Valid colon-separated format tests
@@ -33,18 +36,44 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 			input:     "3c:58:5d:55:77:0e",
 			wantAddr:  true,
 			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "valid colon format uppercase",
 			input:     "3C:58:5D:55:77:0E",
 			wantAddr:  true,
 			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "valid colon format mixed case",
 			input:     "3c:58:5D:55:77:0e",
 			wantAddr:  true,
 			wantValid: true,
+			wantError: "",
+		},
+		
+		// Valid dash-separated format tests
+		{
+			name:      "valid dash format lowercase",
+			input:     "3c-58-5d-55-77-0e",
+			wantAddr:  true,
+			wantValid: true,
+			wantError: "",
+		},
+		{
+			name:      "valid dash format uppercase",
+			input:     "3C-58-5D-55-77-0E",
+			wantAddr:  true,
+			wantValid: true,
+			wantError: "",
+		},
+		{
+			name:      "valid dash format mixed case",
+			input:     "3c-58-5D-55-77-0e",
+			wantAddr:  true,
+			wantValid: true,
+			wantError: "",
 		},
 		
 		// Partial input tests (should be valid but no address)
@@ -53,24 +82,35 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 			input:     "0x3c58",
 			wantAddr:  false,
 			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "partial colon input",
 			input:     "3c:58:5d",
 			wantAddr:  false,
 			wantValid: true,
+			wantError: "",
+		},
+		{
+			name:      "partial dash input",
+			input:     "3c-58-5d",
+			wantAddr:  false,
+			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "empty input",
 			input:     "",
 			wantAddr:  false,
 			wantValid: true,
+			wantError: "",
 		},
 		{
 			name:      "single character",
 			input:     "3",
 			wantAddr:  false,
 			wantValid: true,
+			wantError: "",
 		},
 		
 		// Invalid format tests
@@ -79,52 +119,76 @@ func TestValidateAndParseMACAddress(t *testing.T) {
 			input:     "0x3c585d55770e123456",
 			wantAddr:  false,
 			wantValid: false,
+			wantError: "MAC address too long (max 20 characters)",
 		},
 		{
 			name:      "too long colon format",
 			input:     "3c:58:5d:55:77:0e:12:34",
 			wantAddr:  false,
 			wantValid: false,
+			wantError: "Invalid MAC address format",
 		},
 		{
-			name:      "invalid hex characters",
-			input:     "0x3c585d55770g",
+			name:      "too long dash format",
+			input:     "3c-58-5d-55-77-0e-12-34",
 			wantAddr:  false,
-			wantValid: true, // Should allow typing until complete
+			wantValid: false,
+			wantError: "Invalid MAC address format",
+		},
+		{
+			name:      "invalid hex characters in colon format",
+			input:     "3c:58:5d:55:77:0g",
+			wantAddr:  false,
+			wantValid: true, // Should allow typing
+			wantError: "Invalid character: g",
+		},
+		{
+			name:      "invalid hex characters in dash format",
+			input:     "3c-58-5d-55-77-0z",
+			wantAddr:  false,
+			wantValid: true, // Should allow typing
+			wantError: "Invalid character: z",
 		},
 		{
 			name:      "malformed colon format",
 			input:     "3c:58:5d:55:77:0e:",
 			wantAddr:  false,
 			wantValid: true, // Should allow typing
+			wantError: "",
 		},
 		{
 			name:      "too many characters",
 			input:     "012345678901234567890", // 21 characters
 			wantAddr:  false,
 			wantValid: false,
+			wantError: "MAC address too long (max 20 characters)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr, valid := validateAndParseMACAddress(tt.input)
+			result := validateAndParseMACAddress(tt.input)
 			
-			if valid != tt.wantValid {
-				t.Errorf("validateAndParseMACAddress(%q) valid = %v, want %v", tt.input, valid, tt.wantValid)
+			if result.Valid != tt.wantValid {
+				t.Errorf("validateAndParseMACAddress(%q) valid = %v, want %v", tt.input, result.Valid, tt.wantValid)
 			}
 			
-			if tt.wantAddr && addr == nil {
+			if tt.wantAddr && result.Address == nil {
 				t.Errorf("validateAndParseMACAddress(%q) returned nil address, want non-nil", tt.input)
 			}
 			
-			if !tt.wantAddr && addr != nil {
-				t.Errorf("validateAndParseMACAddress(%q) returned non-nil address %v, want nil", tt.input, addr)
+			if !tt.wantAddr && result.Address != nil {
+				t.Errorf("validateAndParseMACAddress(%q) returned non-nil address %v, want nil", tt.input, result.Address)
 			}
 			
 			// Verify the parsed address has correct length when non-nil
-			if addr != nil && len(addr) != 6 {
-				t.Errorf("validateAndParseMACAddress(%q) returned address with length %d, want 6", tt.input, len(addr))
+			if result.Address != nil && len(result.Address) != 6 {
+				t.Errorf("validateAndParseMACAddress(%q) returned address with length %d, want 6", tt.input, len(result.Address))
+			}
+			
+			// Check error message
+			if result.Error != tt.wantError {
+				t.Errorf("validateAndParseMACAddress(%q) error = %q, want %q", tt.input, result.Error, tt.wantError)
 			}
 		})
 	}
@@ -148,35 +212,96 @@ func TestValidateAndParseMACAddressValues(t *testing.T) {
 			wantAddr: packemon.HardwareAddr{0x3c, 0x58, 0x5d, 0x55, 0x77, 0x0e},
 		},
 		{
-			name:     "all zeros",
+			name:     "dash format specific value",
+			input:    "3c-58-5d-55-77-0e",
+			wantAddr: packemon.HardwareAddr{0x3c, 0x58, 0x5d, 0x55, 0x77, 0x0e},
+		},
+		{
+			name:     "all zeros colon",
 			input:    "00:00:00:00:00:00",
 			wantAddr: packemon.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 		{
-			name:     "all ones (broadcast)",
+			name:     "all zeros dash",
+			input:    "00-00-00-00-00-00",
+			wantAddr: packemon.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+		},
+		{
+			name:     "all ones (broadcast) colon",
 			input:    "ff:ff:ff:ff:ff:ff",
+			wantAddr: packemon.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		},
+		{
+			name:     "all ones (broadcast) dash",
+			input:    "ff-ff-ff-ff-ff-ff",
 			wantAddr: packemon.HardwareAddr{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addr, valid := validateAndParseMACAddress(tt.input)
+			result := validateAndParseMACAddress(tt.input)
 			
-			if !valid {
+			if !result.Valid {
 				t.Fatalf("validateAndParseMACAddress(%q) validation failed", tt.input)
 			}
 			
-			if addr == nil {
+			if result.Address == nil {
 				t.Fatalf("validateAndParseMACAddress(%q) returned nil address", tt.input)
 			}
 			
 			// Compare byte by byte
 			for i := 0; i < len(tt.wantAddr); i++ {
-				if addr[i] != tt.wantAddr[i] {
+				if result.Address[i] != tt.wantAddr[i] {
 					t.Errorf("validateAndParseMACAddress(%q) byte %d = %02x, want %02x", 
-						tt.input, i, addr[i], tt.wantAddr[i])
+						tt.input, i, result.Address[i], tt.wantAddr[i])
 				}
+			}
+		})
+	}
+}
+
+// Test error message extraction
+func TestValidateAndParseMACAddressErrorMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantError string
+	}{
+		{
+			name:      "too long input",
+			input:     "123456789012345678901",
+			wantError: "MAC address too long (max 20 characters)",
+		},
+		{
+			name:      "invalid character in colon format",
+			input:     "3c:58:5d:55:77:XX",
+			wantError: "Invalid character: X",
+		},
+		{
+			name:      "invalid character in dash format",
+			input:     "3c-58-5d-55-77-@#",
+			wantError: "Invalid character: @",
+		},
+		{
+			name:      "too many segments colon",
+			input:     "3c:58:5d:55:77:0e:aa",
+			wantError: "Invalid MAC address format",
+		},
+		{
+			name:      "too many segments dash",
+			input:     "3c-58-5d-55-77-0e-bb",
+			wantError: "Invalid MAC address format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateAndParseMACAddress(tt.input)
+			
+			if result.Error != tt.wantError {
+				t.Errorf("validateAndParseMACAddress(%q) error = %q, want %q", 
+					tt.input, result.Error, tt.wantError)
 			}
 		})
 	}


### PR DESCRIPTION
…t fields

- Increased MAC address input field width from 14 to 20 characters
- Added support for colon-separated format (e.g., 3c:58:5d:55:77:0e)
- Maintains support for hex format (e.g., 0x3c585d55770e)
- Updated parsing logic to handle both formats correctly

Fixes #146 