### PR TITLE
Fix DNS Query on TCP

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -170,3 +170,12 @@ func (d *DNS) Bytes() []byte {
 	}
 	return buf.Bytes()
 }
+
+// TCPでDNSクエリを投げるときは、DNSクエリ長を先頭につけるため
+func (d *DNS) BytesForTCP() []byte {
+	buf := make([]byte, 2)
+	dnsQueryBytes := d.Bytes()
+	length := len(dnsQueryBytes)
+	binary.BigEndian.PutUint16(buf, uint16(length))
+	return append(buf, dnsQueryBytes...)
+}

--- a/internal/tui/generator/sender_current_l7.go
+++ b/internal/tui/generator/sender_current_l7.go
@@ -73,7 +73,7 @@ func (s *sender) sendL7(ctx context.Context, selectedL7, selectedL5_6, selectedL
 							s.packets.ethernet,
 							s.packets.ipv4,
 							s.packets.tcp,
-							s.packets.dns.Bytes(),
+							s.packets.dns.BytesForTCP(),
 						)
 					case "IPv6":
 						return packemon.EstablishConnectionAndSendPayloadXxxForIPv6(
@@ -82,7 +82,7 @@ func (s *sender) sendL7(ctx context.Context, selectedL7, selectedL5_6, selectedL
 							s.packets.ethernet,
 							s.packets.ipv6,
 							s.packets.tcp,
-							s.packets.dns.Bytes(),
+							s.packets.dns.BytesForTCP(),
 						)
 					case "ARP":
 						return fmt.Errorf("unsupported under protocol: %s", selectedL3)
@@ -93,7 +93,7 @@ func (s *sender) sendL7(ctx context.Context, selectedL7, selectedL5_6, selectedL
 					if checkedCalcTCPChecksum {
 						s.packets.tcp.Checksum = 0x0000
 					}
-					s.packets.tcp.Data = s.packets.dns.Bytes()
+					s.packets.tcp.Data = s.packets.dns.BytesForTCP()
 					ethernetFrame := &packemon.EthernetFrame{
 						Header: s.packets.ethernet,
 					}


### PR DESCRIPTION
When sending DNS queries via TCP, it was necessary to prefix the DNS query length, so this was corrected.